### PR TITLE
Fix compatibility with modern Rcpp/RcppEigen and C++14

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ HyPrColoc is an efficient deterministic Bayesian divisive clustering algorithm u
 ## Installation
 ```
 install.packages("remotes")
-remotes::install_version("RcppEigen", version = "0.3.3.9.3")
 remotes::install_github("jrs95/hyprcoloc", build_vignettes = TRUE)
 ```
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,6 @@
+## Use C++14 standard to avoid timespec_get issues
+CXX_STD = CXX14
+
+## Compilation flags
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,6 @@
+## Use C++14 standard to avoid timespec_get issues
+CXX_STD = CXX14
+
+## Compilation flags for Windows
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
+PKG_LIBS = $(SHLIB_OPENMP_CXXFLAGS) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/align1.cpp
+++ b/src/align1.cpp
@@ -1,16 +1,12 @@
 //Includes/namespaces
-#include <Rcpp.h>
 #include <RcppEigen.h>
-#include <iostream>
-#include <Eigen/Core>
 // [[Rcpp::depends(RcppEigen)]]
 
 using namespace Rcpp;
-using namespace RcppEigen;
 using Eigen::Map;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
-using Rcpp::as;
+
 // [[Rcpp::export]]
 
 List align1(NumericMatrix Zmatrix, NumericMatrix Wmatrix, NumericVector N_CV, NumericVector traitsCo, NumericVector traitNo, NumericMatrix trait_cor, NumericMatrix rho, NumericVector EPS){

--- a/src/align12.cpp
+++ b/src/align12.cpp
@@ -1,16 +1,12 @@
 //Includes/namespaces
-#include <Rcpp.h>
 #include <RcppEigen.h>
-#include <iostream>
-#include <Eigen/Core>
 // [[Rcpp::depends(RcppEigen)]]
 
 using namespace Rcpp;
-using namespace RcppEigen;
 using Eigen::Map;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
-using Rcpp::as;
+
 // [[Rcpp::export]]
 
 List align12(NumericMatrix Zmatrix, NumericMatrix Wmatrix, NumericMatrix sTemp1, NumericVector traitsCo, NumericVector traitNo, NumericMatrix rho, NumericMatrix trait_cor, NumericVector EPS){

--- a/src/align1ind.cpp
+++ b/src/align1ind.cpp
@@ -1,16 +1,12 @@
 //Includes/namespaces
-#include <Rcpp.h>
 #include <RcppEigen.h>
-#include <iostream>
-#include <Eigen/Core>
 // [[Rcpp::depends(RcppEigen)]]
 
 using namespace Rcpp;
-using namespace RcppEigen;
 using Eigen::Map;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
-using Rcpp::as;
+
 // [[Rcpp::export]]
 
 List align1ind(NumericMatrix Zmatrix, NumericMatrix Wmatrix, NumericVector traitsCo, NumericVector traitNo){

--- a/src/align2.cpp
+++ b/src/align2.cpp
@@ -1,16 +1,12 @@
 //Includes/namespaces
-#include <Rcpp.h>
 #include <RcppEigen.h>
-#include <iostream>
-#include <Eigen/Core>
 // [[Rcpp::depends(RcppEigen)]]
 
 using namespace Rcpp;
-using namespace RcppEigen;
 using Eigen::Map;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
-using Rcpp::as;
+
 // [[Rcpp::export]]
 
 List align2(NumericMatrix Zmatrix, NumericMatrix Wmatrix, NumericMatrix sTemp1, NumericVector traitsCo, NumericVector traitNo, NumericMatrix rho, NumericMatrix trait_cor, NumericVector EPS){
@@ -177,7 +173,7 @@ List align2(NumericMatrix Zmatrix, NumericMatrix Wmatrix, NumericMatrix sTemp1, 
   VectorXd Wco(Map<VectorXd>(W1.data(), n_cv*ncolZco));
 
   for (int m = 0; m < ncolZco; m++){
-   tmp_rho(i) = RHO(snps1(1 , i)-1, snps1(0 , i)-1);
+   tmp_rho(i) = RHO(int(snps1(1 , i))-1, int(snps1(0 , i))-1);
    tmp_rho_11(2*m+1) = tmp_rho(i);
    tmp_rho_12(2*m) = tmp_rho(i);
    tmp_rho_21(2*m+1) = tmp_rho(i);
@@ -210,8 +206,8 @@ List align2(NumericMatrix Zmatrix, NumericMatrix Wmatrix, NumericMatrix sTemp1, 
     Wdiag_1 = W_1cv.row(iter_1).asDiagonal();
 
     for (int m = 0; m < ncolZco; m++){
-     snp_cor_1cv(2*m) = RHO(snps1(0,i)-1, j2)*tet_1cv(2*m);
-     snp_cor_1cv(2*m+1) = RHO(snps1(1,i)-1, j2)*tet_1cv(2*m+1);
+     snp_cor_1cv(2*m) = RHO(int(snps1(0,i))-1, j2)*tet_1cv(2*m);
+     snp_cor_1cv(2*m+1) = RHO(int(snps1(1,i))-1, j2)*tet_1cv(2*m+1);
     }
 
     snp_cor_1cv(sigZdim - n_cv) = sigZ1_new(sigZdim - n_cv,sigZdim - n_cv);
@@ -262,10 +258,10 @@ List align2(NumericMatrix Zmatrix, NumericMatrix Wmatrix, NumericMatrix sTemp1, 
     Wdiag_2 = W_2cv.row(iter_2).asDiagonal();
 
     for (int m = 0; m < ncolZco; m++){
-     snp_cor_2cv(2*m) = RHO(snps1(0,i)-1, snps1(0,j2)-1)*tet_2cv(2*m);
-     snp_cor_2cv(2*m+1) = RHO(snps1(1,i)-1, snps1(0,j2)-1)*tet_2cv(2*m+1);
-     snp_cor_2cv_1(2*m) = RHO(snps1(0,i)-1, snps1(1,j2)-1)*tet_2cv(2*m);
-     snp_cor_2cv_1(2*m+1) = RHO(snps1(1,i)-1, snps1(1,j2)-1)*tet_2cv(2*m+1);
+     snp_cor_2cv(2*m) = RHO(int(snps1(0,i))-1, int(snps1(0,j2))-1)*tet_2cv(2*m);
+     snp_cor_2cv(2*m+1) = RHO(int(snps1(1,i))-1, int(snps1(0,j2))-1)*tet_2cv(2*m+1);
+     snp_cor_2cv_1(2*m) = RHO(int(snps1(0,i))-1, int(snps1(1,j2))-1)*tet_2cv(2*m);
+     snp_cor_2cv_1(2*m+1) = RHO(int(snps1(1,i))-1, int(snps1(1,j2))-1)*tet_2cv(2*m+1);
     }
 
     snp_cor_2cv(sigZdim - n_cv) = sigZ2_new(sigZdim - n_cv, sigZdim - n_cv);
@@ -274,8 +270,8 @@ List align2(NumericMatrix Zmatrix, NumericMatrix Wmatrix, NumericMatrix sTemp1, 
     sigZ2.col(sigZdim - n_cv) = snp_cor_2cv;
     sigZ2.row(sigZdim - 1) = snp_cor_2cv_1;
     sigZ2.col(sigZdim - 1) = snp_cor_2cv_1;
-    sigZ2(2*ncolZco+1, 2*ncolZco) = RHO(snps1(1 , j2)-1, snps1(0 , j2)-1);
-    sigZ2(2*ncolZco, 2*ncolZco+1) = RHO(snps1(1 , j2)-1, snps1(0 , j2)-1);
+    sigZ2(2*ncolZco+1, 2*ncolZco) = RHO(int(snps1(1 , j2))-1, int(snps1(0 , j2))-1);
+    sigZ2(2*ncolZco, 2*ncolZco+1) = RHO(int(snps1(1 , j2))-1, int(snps1(0 , j2))-1);
 
     adjZ_2 = Wdiag_2*sigZ2*Wdiag_2;
 

--- a/src/regional1.cpp
+++ b/src/regional1.cpp
@@ -1,19 +1,14 @@
 //Includes/namespaces
-#include <Rcpp.h>
 #include <RcppEigen.h>
-#include <Eigen/Dense>
-#include <iostream>
-#include <Eigen/Core>
 // [[Rcpp::depends(RcppEigen)]]
 
 using namespace Rcpp;
-using namespace RcppEigen;
 using Eigen::Map;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 using Eigen::ArrayXd;
-using Rcpp::as;
 using Eigen::LLT;
+
 // [[Rcpp::export]]
 
 List regional1(NumericMatrix zTemp1, NumericMatrix wTemp1, NumericVector traitsCo, NumericMatrix trait_cor, NumericVector EPS){

--- a/src/regional1ind.cpp
+++ b/src/regional1ind.cpp
@@ -1,19 +1,14 @@
 //Includes/namespaces
-#include <Rcpp.h>
 #include <RcppEigen.h>
-#include <Eigen/Dense>
-#include <iostream>
-#include <Eigen/Core>
 // [[Rcpp::depends(RcppEigen)]]
 
 using namespace Rcpp;
-using namespace RcppEigen;
 using Eigen::Map;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 using Eigen::ArrayXd;
-using Rcpp::as;
 using Eigen::LLT;
+
 // [[Rcpp::export]]
 
 List regional1ind(NumericMatrix zTemp1, NumericMatrix wTemp1, NumericVector traitsCo){

--- a/src/regional2.cpp
+++ b/src/regional2.cpp
@@ -1,18 +1,13 @@
 //Includes/namespaces
-#include <Rcpp.h>
 #include <RcppEigen.h>
-#include <Eigen/Dense>
-#include <iostream>
-#include <Eigen/Core>
 // [[Rcpp::depends(RcppEigen)]]
 
 using namespace Rcpp;
-using namespace RcppEigen;
 using Eigen::Map;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 using Eigen::ArrayXd;
-using Rcpp::as;
+
 // [[Rcpp::export]]
 
 List regional2(NumericMatrix zTemp1, NumericMatrix wTemp1, NumericMatrix sTemp1, NumericVector traitsCo, NumericMatrix rho, NumericMatrix trait_cor, NumericVector EPS){
@@ -128,7 +123,7 @@ List regional2(NumericMatrix zTemp1, NumericMatrix wTemp1, NumericMatrix sTemp1,
 
   // compute the subseted correlation matrix for co and no-co Z-scores
   for (int k = 0; k < m; k++){
-   tmp_rho(i) = RHO(snps(0 , i)-1, snps(1 , i)-1);
+   tmp_rho(i) = RHO(int(snps(0 , i))-1, int(snps(1 , i))-1);
    tmp_rho_21(2*k+1) = tmp_rho(i);
    tmp_rho_22(2*k) = tmp_rho(i);
   }
@@ -169,7 +164,7 @@ for (int i = Q; i < ncol; i++){
 
   // compute the subseted correlation matrix for coloc Z-scores
   for (int k = 0; k < m; k++){
-   tmp_rho(i) = RHO(snps(0 , i)-1, snps(1 , i)-1);
+   tmp_rho(i) = RHO(int(snps(0 , i))-1, int(snps(1 , i))-1);
    tmp_rho_21(2*k+1) = tmp_rho(i);
    tmp_rho_22(2*k) = tmp_rho(i);
   }


### PR DESCRIPTION
## Problem
The current package fails to compile with modern versions of Rcpp, RcppEigen, and C++14/17 compilers, producing two types of errors:

1. **`::timespec_get` error**: Missing C++ standard definition causes compilation failures
2. **Eigen IndexedView errors**: Modern Eigen/RcppEigen returns `IndexedView` objects instead of scalar values for matrix element access

Users are forced to downgrade their R environment to install this package.

## Solution
This PR makes the following changes to ensure compatibility with current toolchains while maintaining backward compatibility:

### 1. Added Makevars files
- Created `src/Makevars` and `src/Makevars.win`
- Set C++ standard to C++14 to resolve `::timespec_get` issues
- Added proper compiler flags for OpenMP and BLAS/LAPACK

### 2. Updated C++ source file headers
Modified all `.cpp` files (`align1.cpp`, `align12.cpp`, `align1ind.cpp`, `align2.cpp`, `regional1.cpp`, `regional1ind.cpp`, `regional2.cpp`):
- Removed redundant includes (`<iostream>`, `<Eigen/Core>`, `<Eigen/Dense>`)
- Simplified namespace declarations for modern RcppEigen compatibility
- Kept only essential `#include <RcppEigen.h>` with proper depends annotation

### 3. Fixed matrix indexing compatibility
Updated `align2.cpp` and `regional2.cpp`:
- Added explicit `int()` casts for matrix indices to handle Eigen's `IndexedView` return type
- Fixed lines that access matrix elements used in scalar assignments

## Testing
Successfully compiled and installed on:
- Conda R environment with latest Rcpp (1.0.14+), RcppEigen (0.3.4+), and C++14
- No compilation errors or functional issues

## Backward Compatibility
All changes are backward compatible - the package should still compile with older Rcpp/RcppEigen versions.

## Additional Notes
These are minimal, targeted fixes that don't alter any algorithmic logic - only compilation compatibility improvements.